### PR TITLE
Configuration parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.project

--- a/bin/qunit-cli
+++ b/bin/qunit-cli
@@ -52,6 +52,9 @@ if (code) {
   }
 };
 
+// Load QUnit tests
+QUnit.load();
+
 // Run tests
 files.forEach(function(file) {
   require(resolve(file))

--- a/bin/qunit-cli
+++ b/bin/qunit-cli
@@ -52,8 +52,10 @@ if (code) {
   }
 };
 
-// Load QUnit tests
+// Load QUnit test framework
+var config = QUnit.extend({}, QUnit.config);
 QUnit.load();
+QUnit.extend(QUnit.config, config)
 
 // Run tests
 files.forEach(function(file) {

--- a/bin/qunit-cli
+++ b/bin/qunit-cli
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+var fs = require('fs');
+
+var extname = require('path').extname;
+
 // Request at least one test file as parameter
 var argv = require('optimist')
     .alias('code', 'c')
@@ -59,5 +63,27 @@ QUnit.extend(QUnit.config, config)
 
 // Run tests
 files.forEach(function(file) {
-  require(resolve(file))
+  file = resolve(file);
+
+  fs.stat(file, function(error, stats)
+  {
+    if(error) return console.warn(error);
+
+    if(stats.isDirectory())
+      fs.readdir(file, function(error, files)
+      {
+        if(error) return console.warn(error);
+
+        files.forEach(function(name)
+        {
+          name = resolve(file, name);
+
+          if(extname(name) != '.js') return console.warn('Unknown file type:',name)
+
+          require(name)
+        });
+      })
+    else
+      require(file)
+  })
 });

--- a/index.js
+++ b/index.js
@@ -9,19 +9,42 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         colors = require('colors');
 
     var argv = require('optimist')
+        .describe('hidepassed', 'Show only the failing tests, hiding all that pass')
+        .default('hidepassed', false)
         .alias('module', 'm')
         .describe('module', 'Run an individual module')
-        .alias('testNumber', 'test')  /** @deprecated */
+        .describe('requireExpects', 'Require each test to specify the number of expected assertions')
+        .default('requireExpects', false)
         .alias('testNumber', 't')
         .describe('testNumber', 'Run an individual test by number')
+        .describe('test', 'Run an individual test by number (deprecated)')
+        .describe('testTimeout', 'Global timeout in milliseconds after which all tests will fail')
         .alias('quiet', 'q')
-        .describe('quiet', 'Hide passed tests')
+        .describe('quiet', 'Hide passed tests (deprecated)')
         .boolean('quiet')
         .argv;
 
+    // Deprecation notices
+
+    if(argv.test != undefined)
+    {
+      console.warn('"test" parameter is deprecated, please use "testNumber" instead');
+      argv.testNumber = argv.testNumber || argv.test;
+    };
+
+    if(argv.quiet != undefined)
+      console.warn('"quiet" parameter is deprecated, please use "hidepassed" instead');
+
+    // QUnit configurations
+
     QUnit.config.autorun = false;
+
+    QUnit.config.hidepassed = argv.hidepassed;
     QUnit.config.module = argv.module;
+    QUnit.config.requireExpects = argv.requireExpects;
     QUnit.config.testNumber = argv.testNumber;
+    QUnit.config.testTimeout = argv.testTimeout;
+
     module.exports = QUnit;
 
     var errors = [],

--- a/index.js
+++ b/index.js
@@ -71,11 +71,8 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
       delete argv.test;
     };
 
-    if(argv.quiet != undefined)
-    {
+    if(argv.quiet)
       console.warn('"quiet" parameter is deprecated, please use "hidepassed" instead');
-      delete argv.quiet;
-    };
 
     // QUnit configurations
     delete argv.urlConfig;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     var QUnit = require('qunitjs'),
         colors = require('colors');
 
-    var argv = require('optimist')
+    var optimist = require('optimist')
         .describe('hidepassed', 'Show only the failing tests, hiding all that pass')
         .default('hidepassed', false)
         .alias('module', 'm')
@@ -22,7 +22,8 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         .alias('quiet', 'q')
         .describe('quiet', 'Hide passed tests (deprecated)')
         .boolean('quiet')
-        .argv;
+        .describe('urlConfig', 'Add a config parameter of your own in JSON');
+    var argv = optimist.argv;
 
     // Deprecation notices
 
@@ -44,6 +45,39 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     QUnit.config.requireExpects = argv.requireExpects;
     QUnit.config.testNumber = argv.testNumber;
     QUnit.config.testTimeout = argv.testTimeout;
+
+    // Add user own config parameters
+    var urlConfig = argv.urlConfig;
+    if (urlConfig) {
+      function addConfig(urlConfig) {
+        urlConfig = JSON.parse(urlConfig);
+
+        // Add config parameter to QUnit-cli so it can be checked
+        var id    = urlConfig.id;
+        var value = urlConfig.value;
+
+        optimist.describe(id, urlConfig.tooltip || urlConfig.label);
+
+        if(value == undefined)
+          optimist.boolean(id);
+        else if(typeof value == 'string')
+          optimist.boolean(id);
+
+        // Add config parameter to QUnit so it can be processed
+        QUnit.config.urlConfig.push(urlConfig);
+      }
+
+      if (urlConfig instanceof Array) {
+        urlConfig.forEach(function(config) {
+          addConfig(config);
+        });
+      } else {
+        addConfig(urlConfig);
+      }
+    };
+
+    // Check arguments against user own config parameters
+    argv = optimist.argv;
 
     module.exports = QUnit;
 

--- a/index.js
+++ b/index.js
@@ -95,9 +95,20 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     var errors = [],
         printedModule = false;
 
+    function printModule(name)
+    {
+      // Separate each module with an empty line
+      console.log('\n');
+
+      // Only print module name if it's defined
+      if (name)
+          console.log(name.bold.blue);
+    }
+
     // keep track of whether we've printed the module name yet
     QUnit.moduleStart(function(details) {
-        printedModule = false;
+        if (printedModule = !argv.quiet)
+          printModule(details.name);
     });
 
     // when an individual assertion fails, add it to the list of errors to display
@@ -109,15 +120,8 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     // when a test ends, print success/failure and any errors
     QUnit.testDone(function(details) {
         // print the name of each module
-        if (!printedModule && (printedModule = !argv.quiet || details.failed))
-        {
-            // Separate each module with an empty line
-            console.log('\n');
-
-            // Only print module name if it's defined
-            if (details.module)
-                console.log(details.module.bold.blue);
-        }
+        if (!printedModule && details.failed)
+          printModule(details.module);
 
         if (details.failed) {
             console.log(('  ✖ ' + details.name).red);

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         .boolean('quiet');
 
     // Add user own config parameters and if so, override normal ones
+    var consts = {};
+
     var urlConfig = argv.urlConfig;
     if (urlConfig) {
       function addConfig(urlConfig) {
@@ -45,7 +47,13 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         if(value == undefined)
           optimist.boolean(id);
         else if(typeof value == 'string')
+        {
           optimist.boolean(id);
+
+          consts[id] = value;
+        }
+        else if(!(value instanceof Array))
+          optimist.string(id);
 
         // Add config parameter to QUnit so it can be processed
         QUnit.config.urlConfig.push(urlConfig);
@@ -80,7 +88,7 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     QUnit.config.autorun = false;
 
     for(var key in argv)
-      QUnit.config[key] = argv[key];
+      QUnit.config[key] = consts[key] || argv[key];
 
     module.exports = QUnit;
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,14 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     var QUnit = require('qunitjs'),
         colors = require('colors');
 
+    // Get user own config parameters
     var optimist = require('optimist')
+        .describe('urlConfig', 'Add a config parameter of your own in JSON')
+        .string('urlConfig');
+    var argv = optimist.argv;
+
+    // Define normal config parameters
+    optimist
         .describe('hidepassed', 'Show only the failing tests, hiding all that pass')
         .default('hidepassed', false)
         .alias('module', 'm')
@@ -21,32 +28,9 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         .describe('testTimeout', 'Global timeout in milliseconds after which all tests will fail')
         .alias('quiet', 'q')
         .describe('quiet', 'Hide passed tests (deprecated)')
-        .boolean('quiet')
-        .describe('urlConfig', 'Add a config parameter of your own in JSON');
-    var argv = optimist.argv;
+        .boolean('quiet');
 
-    // Deprecation notices
-
-    if(argv.test != undefined)
-    {
-      console.warn('"test" parameter is deprecated, please use "testNumber" instead');
-      argv.testNumber = argv.testNumber || argv.test;
-    };
-
-    if(argv.quiet != undefined)
-      console.warn('"quiet" parameter is deprecated, please use "hidepassed" instead');
-
-    // QUnit configurations
-
-    QUnit.config.autorun = false;
-
-    QUnit.config.hidepassed = argv.hidepassed;
-    QUnit.config.module = argv.module;
-    QUnit.config.requireExpects = argv.requireExpects;
-    QUnit.config.testNumber = argv.testNumber;
-    QUnit.config.testTimeout = argv.testTimeout;
-
-    // Add user own config parameters
+    // Add user own config parameters and if so, override normal ones
     var urlConfig = argv.urlConfig;
     if (urlConfig) {
       function addConfig(urlConfig) {
@@ -76,8 +60,30 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
       }
     };
 
-    // Check arguments against user own config parameters
+    // Check arguments
     argv = optimist.argv;
+
+    // Deprecation notices
+    if(argv.test != undefined)
+    {
+      console.warn('"test" parameter is deprecated, please use "testNumber" instead');
+      argv.testNumber = argv.testNumber || argv.test;
+      delete argv.test;
+    };
+
+    if(argv.quiet != undefined)
+    {
+      console.warn('"quiet" parameter is deprecated, please use "hidepassed" instead');
+      delete argv.quiet;
+    };
+
+    // QUnit configurations
+    delete argv.urlConfig;
+
+    QUnit.config.autorun = false;
+
+    for(var key in argv)
+      QUnit.config[key] = argv[key];
 
     module.exports = QUnit;
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     var argv = require('optimist')
         .alias('module', 'm')
         .describe('module', 'Run an individual module')
-        .alias('test', 't')
-        .describe('test', 'Run an individual test by number')
+        .alias('testNumber', 'test')  /** @deprecated */
+        .alias('testNumber', 't')
+        .describe('testNumber', 'Run an individual test by number')
         .alias('quiet', 'q')
         .describe('quiet', 'Hide passed tests')
         .boolean('quiet')
@@ -20,7 +21,7 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
 
     QUnit.config.autorun = false;
     QUnit.config.module = argv.module;
-    QUnit.config.testNumber = argv.test;
+    QUnit.config.testNumber = argv.testNumber;
     module.exports = QUnit;
 
     var errors = [],

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // Make sure we're in a non-browser environment
 if (typeof QUnit === 'undefined' && typeof require === 'function') {
-    // Currently requires an old version of QUnit because 
+    // Currently requires an old version of QUnit because
     // of a regression that breaks Node.js compatibility.
     // See https://github.com/jquery/qunit/pull/401
     var QUnit = require('qunitjs'),
@@ -41,7 +41,14 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
     QUnit.testDone(function(details) {
         // print the name of each module
         if (!printedModule && (printedModule = !argv.quiet || details.failed))
-            console.log('\n' + details.module.bold.blue);
+        {
+            // Separate each module with an empty line
+            console.log('\n');
+
+            // Only print module name if it's defined
+            if (details.module)
+                console.log(details.module.bold.blue);
+        }
 
         if (details.failed) {
             console.log(('  ✖ ' + details.name).red);
@@ -70,7 +77,7 @@ if (typeof QUnit === 'undefined' && typeof require === 'function') {
         else
             console.log((msg + '.').green.bold);
 
-        process.once('exit', function() {    
+        process.once('exit', function() {
             process.exit(details.failed);
         });
     });

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "bugs": "http://github.com/devongovett/qunit/issues",
   "dependencies": {
       "colors": "*",
-      "qunitjs": "1.14.x",
-      "optimist": ">=0.6"
+      "qunitjs": "^1.10.x",
+      "optimist": ">=0.3"
   },
-  "bin": "bin/qunit-cli"
+  "bin": "bin/qunit-cli",
+  "preferGlobal": true
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "bugs": "http://github.com/devongovett/qunit/issues",
   "dependencies": {
       "colors": "*",
-      "qunitjs": "1.10.x",
-      "optimist": ">=0.3"
+      "qunitjs": "1.14.x",
+      "optimist": ">=0.6"
   },
   "bin": "bin/qunit-cli"
 }

--- a/readme.md
+++ b/readme.md
@@ -10,34 +10,60 @@ testing framework.
 
 There are two ways to use qunit-cli:
 
-1. Include it at the top of your test files. First, install the module using npm.
+1.  Include it at the top of your test files. First, install the module using
+    npm.
 
-        npm install qunit-cli
+    ```bash
+    npm install qunit-cli
+    ```
 
     And now, require it in your test files:
 
-        if (typeof QUnit == 'undefined') // if your tests also run in the browser...
-            QUnit = require('qunit-cli');
-        
-        // use QUnit as you normally would.
+    ```Javascript
+    if (typeof QUnit == 'undefined') // if your tests also run in the browser...
+    QUnit = require('qunit-cli');
 
-    Note that this module does not introduce QUnit into the global scope like QUnit
-    does in the browser, so you'll have to do that yourself if needed.
+    // use QUnit as you normally would.
+    ```
+
+    Note that this module does not introduce QUnit into the global scope like
+    QUnit does in the browser, so you'll have to do that yourself if needed:
+
+    ```Javascript
+    // you can use directly the QUnit namespace...
+    QUnit.module('blah');
+
+    // ...or you can set the QUnit exports to variables as you normally would,
+    // or set them to the 'global' namespace so they can be available everywhere
+    // in your code, but this is considered a bad practice.
+    var asyncTest = QUnit.asyncTest;
+    global.ok = QUnit.ok;
+
+    asyncTest('foo', function()
+    {
+      // 'ok' has been asigned to the global namespace
+      ok(true);
+    });
+    ```
 
     To run, use the `node` program.
 
-        node mytests.js
+    ```bash
+    node mytests.js
+    ```
 
-2. Use the command-line testrunner located at `bin/qunit-cli`, passing it the test files as arguments.
-    If you install the module globally using npm, you can use the `qunit-cli` command which will be 
-    installed into your PATH.
+2.  Use the command-line testrunner located at `bin/qunit-cli`, passing it the
+    test files as arguments. If you install the module globally using npm, you
+    can use the `qunit-cli` command which will be installed into your PATH.
 
-        npm install qunit-cli -g
-        qunit-cli mytests.js
+    ```bash
+    npm install qunit-cli -g
+    qunit-cli mytests.js
+    ```
 
-    This will introduce QUnit into the global scope like QUnit does in the browser,
-    so you don't need to modify the tests themselves. You can use both methods in
-    the same test files without problems.
+    This will introduce QUnit into the global scope like QUnit does in the
+    browser, so you don't need to modify the tests themselves. You can use both
+    methods in the same test files without problems.
 
 ## Command line options
 

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,9 @@ There are several command line options available when running your tests using
 qunit-cli that mimic some of the options in the standard browser-based QUnit
 testing interface.  They are:
 
-    --module, -m    Limits testing to an individual module
-    --test,   -t    Limits testing to a single test (by number)
-    --quiet,  -q    Flag to hide passed tests from the output
+    --module,     -m    Limits testing to an individual module
+    --testNumber, -t    Limits testing to a single test (by number)
+    --quiet,      -q    Flag to hide passed tests from the output
 
 The command-line test runner has some additional options available:
 

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,13 @@ There are several command line options available when running your tests using
 qunit-cli that mimic some of the options in the standard browser-based QUnit
 testing interface.  They are:
 
-    --module,     -m    Limits testing to an individual module
-    --testNumber, -t    Limits testing to a single test (by number)
-    --quiet,      -q    Flag to hide passed tests from the output
+    --hidepassed,           Show only the failing tests, hiding all that pass
+    --module,         -m    Limits testing to an individual module
+    --requireExpects,       Require each test to specify the number of expected assertions
+    --testNumber,     -t    Limits testing to a single test (by number)
+    --testTimeout,          Global timeout in milliseconds after which all tests will fail
+    --quiet,          -q    Flag to hide passed tests from the output (deprecated)
+    --urlConfig,            Add a config parameter of your own in JSON
 
 The command-line test runner has some additional options available:
 


### PR DESCRIPTION
Allow to use from command line all the QUnit parameters that are not directly related with tests representation on a browser environment, including to add new parameters with QUnit uriConfig.
