### PR TITLE
Improve Windows support

### DIFF
--- a/bin/qunit-cli
+++ b/bin/qunit-cli
@@ -8,8 +8,9 @@ var argv = require('optimist')
     .argv;
 
 var assign = require('object-assign')
+var globArgs = require('glob-args')
 
-var files = argv._;
+var files = globArgs(argv._);
 
 // Resolve modules
 var resolve = require('path').resolve;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://badassjs.com/"
   },
   "scripts": {
-    "test": "./bin/qunit-cli ./test/simple.js"
+    "test": "node bin/qunit-cli test/*.js"
   },
   "repository": {
     "type": "git",
@@ -17,6 +17,7 @@
   "bugs": "http://github.com/devongovett/qunit/issues",
   "dependencies": {
     "colors": "*",
+    "glob-args": "^0.2.0",
     "object-assign": "^2.0.0",
     "optimist": ">=0.3",
     "qunitjs": "^1.15.0"


### PR DESCRIPTION
This PR adds arguments globing, and makes the test run on Windows.

Currently `qunit-cli` does not support globing. This is however, how it is used in the wild, [like in underscore](https://github.com/jashkenas/underscore/blob/master/package.json#L38):
```json
"test-node": "qunit-cli test/*.js",
```

`underscore` (and some other packages that use `qunit-cli`) are used by Node.js to test new releases (see [CITGM](https://github.com/nodejs/citgm)). Because globing does not work, those are currently skipped on Windows.
